### PR TITLE
Add Optionals Section to the Swift Style Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ Otherwise, it's advisable to introduce new names, but avoid using names like `un
 private var greetingName: String?
 private var greetingText: String?
 
-if let userGreetingName = greetingName, let inputGreetingText = greetingText {
+if 
+let userGreetingName = greetingName, 
+let inputGreetingText = greetingText {
      // ... do something with unwrapped values
 }
 ```
@@ -202,7 +204,9 @@ if let userGreetingName = greetingName, let inputGreetingText = greetingText {
 private var greetingName: String?
 private var greetingText: String?
 
-if let actualGreetingName = greetingName, let unwrappedGreetingText = greetingText {
+if 
+let actualGreetingName = greetingName, 
+let unwrappedGreetingText = greetingText {
    // ... do something with unwrapped values
 }
 ```
@@ -239,15 +243,22 @@ enjoyShopping()
 
 When multiple optionals are unwrapped either with `guard` or `if let`, minimize nesting by using the compound version when possible.
 
+Additionally, for better readability and debugging, place the `guard` / `if` on its own line, and then indent each condition on a separate line.
+
 
 **Recommended ✅**
 
 ```swift
-if let username, let password, let passcode {
-    // ... do something with unwrapped values
-} else {
-    fatalError("Authentication Failed")
+guard 
+  let username,
+  let email,
+  let password,
+  let passcode,
+  let securityAnswer
+else {
+  fatalError("Authentication Failed")
 }
+// ... do something with unwrapped values
 ```
 
 **Not Recommended ❌**
@@ -266,25 +277,6 @@ if let username {
 } else {
     fatalError("Authentication Failed")
 }
-```
-
-
-In the compound version, which can't be fit on one line, place the `guard` / `if` on its own line, then indent each condition on a separate line.
-
-
-**Recommended ✅**
-
-```swift
-guard 
-  let username,
-  let email,
-  let password,
-  let passcode,
-  let securityAnswer
-else {
-  fatalError("Authentication Failed")
-}
-// ... do something with unwrapped values
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ private var currency: String? = nil
 
 #### 1. Force Unwrapping
 
-Implicitly unwrapped optionals are inherently unsafe and should be avoided whenever possible. Instead, use non-optional values or normal optionals. It’s safer and more reliable, even if you think a value will never be `nil`. Even in situations where you feel confident that a property will never be `nil`, it's better to prioritize safety and consistency.
+Implicitly unwrapped optionals are inherently unsafe and should be avoided whenever possible. Instead, use non-optional values or normal optionals. Even in situations where you feel confident that a property will never be `nil`, it's better to prioritize safety and consistency.
 
 ❗️The only time implicitly unwrapped optionals are used is with `@IBOutlets`, where their lifetimes are tied to the UI lifecycle rather than strictly to the owning object.
 

--- a/README.md
+++ b/README.md
@@ -112,3 +112,25 @@ class SomeViewController: UIViewController {
 }
 ```
 
+
+#### 2. Checking for `nil`
+
+When there's a need to verify the presence of a value in an optional without using it, preferring direct checking against nil over optional binding is clearer and more explicit.
+
+
+**Recommended ✅**
+
+```swift
+if userId != nil {
+  // ... do something 
+}
+```
+
+**Not Recommended ❌**
+
+```swift
+if let _ = userId {
+  // ... do something 
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -70,3 +70,9 @@ func calculatePerimeterOfRectangle(first: Int, second: Int, third: Int, forth: I
 ```
 
 ## Optionals
+
+### Declaring Optionals
+
+* Declare Declare optional constants/variables and function return types as optional to convey a non-error result that is either a value or the absence of a value (`nil`).
+
+* When creating Models of API responses (JSON data), always declare properties as optionals to ensure handling situations where certain properties may not have a value in the received data. 

--- a/README.md
+++ b/README.md
@@ -91,3 +91,24 @@ private var currency: String?
 ```swift
 private var currency: String? = nil
 ```
+
+
+### Unwrapping Optionals
+
+#### 1. Force Unwrapping
+
+Implicitly unwrapped optionals are inherently unsafe and should be avoided whenever possible. Instead, use non-optional values or normal optionals. It’s safer and more reliable, even if you think a value will never be `nil`. Even in situations where you feel confident that a property will never be `nil`, it's better to prioritize safety and consistency.
+
+❗️The only time implicitly unwrapped optionals are used is with `@IBOutlets`, where their lifetimes are tied to the UI lifecycle rather than strictly to the owning object.
+
+
+**Recommended ✅**
+
+```swift
+class SomeViewController: UIViewController {
+
+  @IBOutlet private weak var saveButton: UIButton!
+  
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ func calculatePerimeterOfRectangle(first: Int, second: Int, third: Int, forth: I
   // calculate code goes here
 }
 ```
+
+## Optionals

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ enjoyShopping()
 ```
 
 
-When multiple optionals are unwrapped either with `guard` or `if let`, minimize nesting by using the compound version when possible.
+When multiple optionals are unwrapped either with `guard` or `if` statement, minimize nesting by using the compound version when possible.
 
 Additionally, for better readability and debugging, place the `guard` / `if` on its own line, and then indent each condition on a separate line.
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class SomeViewController: UIViewController {
 
 **`weak` VS `unowned`**
 
-Always prefer using `weak` over `unowned` since we don't ever want to have implicit unwraps because it is an equivalent of a weak property that is implicitly unwrapped. 
+It’s advisable to prefer the use of `weak` over `unowned`. Implicit unwrapping should be avoided whenever possible, as `unowned` is essentially a `weak` property that is implicitly unwrapped.
 
 **Recommended ✅**
 
@@ -284,7 +284,7 @@ guard
 else {
   fatalError("Authentication Failed")
 }
-// ... do something with values
+// ... do something with unwrapped values
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -591,23 +591,6 @@ enjoyShopping()
 
 When multiple optionals are unwrapped either with `guard` or `if` statement, minimize nesting by using the compound version when possible.
 
-Additionally, for better readability and debugging, place the `guard` / `if` on its own line, and then indent each condition on a separate line.
-
-
-**Recommended ✅**
-
-```swift
-guard 
-  let username,
-  let email,
-  let password,
-  let passcode,
-  let securityAnswer
-else {
-  fatalError("Authentication Failed")
-}
-// ... do something with unwrapped values
-```
 
 **Not Recommended ❌**
 
@@ -632,6 +615,7 @@ if let username {
 
 Use the nil-coalescing operator as a shorthand method to provide a fallback value when unwrapping an optional, instead of using the ternary conditional operator and forced unwrapping.
 
+
 **Recommended ✅**
 
 ```swift
@@ -649,4 +633,3 @@ private var userDefinedDepositName: String?
 
 private var depositNameToDisplay = userDefinedDepositName != nil ? userDefinedDepositName! : depositDefaultName
 ```
-

--- a/README.md
+++ b/README.md
@@ -113,6 +113,25 @@ class SomeViewController: UIViewController {
 ```
 
 
+**`weak` VS `unowned`**
+
+Always prefer using `weak` over `unowned` since we don't ever want to have implicit unwraps because it is an equivalent of a weak property that is implicitly unwrapped. 
+
+**Recommended ✅**
+
+```swift
+private weak var parentViewController: UIViewController?
+```
+
+**Not Recommended ❌**
+
+```swift
+private weak var parentViewController: UIViewController!
+
+private unowned var parentViewController: UIViewController
+```
+
+
 #### 2. Checking for `nil`
 
 When there's a need to verify the presence of a value in an optional without using it, preferring direct checking against nil over optional binding is clearer and more explicit.

--- a/README.md
+++ b/README.md
@@ -134,3 +134,25 @@ if let _ = userId {
 }
 ```
 
+
+### Providing Fallback Value
+
+Use the nil-coalescing operator as a shorthand method to provide a fallback value when unwrapping an optional, instead of using the ternary conditional operator and forced unwrapping.
+
+**Recommended ✅**
+
+```swift
+private let depositDefaultName = "My Piggy"
+private var userDefinedDepositName: String?
+
+private var depositNameToDisplay = userDefinedDepositName ?? depositDefaultName
+```
+
+**Not Recommended ❌**
+
+```swift
+private let depositDefaultName = "My Piggy"
+private var userDefinedDepositName: String?
+
+private var depositNameToDisplay = userDefinedDepositName != nil ? userDefinedDepositName! : depositDefaultName
+```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ func calculatePerimeterOfRectangle(first: Int, second: Int, third: Int, forth: I
 
 ### Declaring Optionals
 
-* Declare Declare optional constants/variables and function return types as optional to convey a non-error result that is either a value or the absence of a value (`nil`).
+Declare optional constants/variables and function return types as optional to convey a non-error result that is either a value or the absence of a value (`nil`).
 
-* When creating Models of API responses (JSON data), always declare properties as optionals to ensure handling situations where certain properties may not have a value in the received data. 
+When creating Models of API responses (JSON data), always declare properties as optionals to ensure handling situations where certain properties may not have a value in the received data. 
+
+Define an optional variable that does not have a default value without explicitly assigning it to `nil`.
+
+
+**Recommended ✅**
+
+```swift
+private var currency: String?
+```
+
+**Not Recommended ❌**
+
+```swift
+private var currency: String? = nil
+```

--- a/README.md
+++ b/README.md
@@ -542,12 +542,9 @@ Otherwise, it's advisable to introduce new names, but avoid using names like `un
 **Recommended ✅**
 
 ```swift
-private var greetingName: String?
 private var greetingText: String?
 
-if 
-let userGreetingName = greetingName, 
-let inputGreetingText = greetingText {
+if let inputGreetingText = greetingText {
      // ... do something with unwrapped values
 }
 ```
@@ -555,12 +552,9 @@ let inputGreetingText = greetingText {
 **Not Recommended ❌**
 
 ```swift
-private var greetingName: String?
 private var greetingText: String?
 
-if 
-let actualGreetingName = greetingName, 
-let unwrappedGreetingText = greetingText {
+if let unwrappedGreetingText = greetingText {
    // ... do something with unwrapped values
 }
 ```

--- a/README.md
+++ b/README.md
@@ -655,3 +655,4 @@ private var userDefinedDepositName: String?
 
 private var depositNameToDisplay = userDefinedDepositName != nil ? userDefinedDepositName! : depositDefaultName
 ```
+

--- a/README.md
+++ b/README.md
@@ -135,6 +135,140 @@ if let _ = userId {
 ```
 
 
+#### 3. Optional Binding
+
+Use conditional unwrap with optional binding to access the optional’s value if it does exist and to make that value available as a temporary constant or variable. 
+
+If there's no need to reference the original optional constant or variable after accessing the value it contains, the existing name can be shadowed using the shorthand syntax.
+
+
+**Recommended ✅**
+
+```swift
+private var greetingName: String? = "Stranger"
+
+if let greetingName {
+    print("Hello, \(greetingName)!")
+}
+```
+
+**Not Recommended ❌**
+
+```swift
+private var greetingName: String? = "Stranger"
+
+if let greetingName = greetingName {
+    print("Hello, \(greetingName)!")
+}
+```
+
+
+Otherwise, it's advisable to introduce new names, but avoid using names like `unwrappedView` or `actualLabel` and so on.
+
+
+**Recommended ✅**
+
+```swift
+private var greetingName: String?
+private var greetingText: String?
+
+if let userGreetingName = greetingName, let inputGreetingText = greetingText {
+     // ... do something with unwrapped values
+}
+```
+
+**Not Recommended ❌**
+
+```swift
+private var greetingName: String?
+private var greetingText: String?
+
+if let actualGreetingName = greetingName, let unwrappedGreetingText = greetingText {
+   // ... do something with unwrapped values
+}
+```
+
+
+When unwrapping optionals, prefer `guard` statements as opposed to `if` statements to decrease the amount of nested indentation in the code.
+
+
+**Recommended ✅**
+
+```swift
+guard let creditSale else { return }
+requestCredit(using: creditSale)
+enjoyShopping()
+```
+
+**Not Recommended ❌**
+
+```swift
+if let creditSale {
+    requestCredit(using: creditSale)
+    enjoyShopping()
+}
+```
+
+**Not Recommended ❌**
+
+```swift
+if creditSale == nil { return }
+requestCredit(using: creditSale)
+enjoyShopping()
+```
+
+
+When multiple optionals are unwrapped either with `guard` or `if let`, minimize nesting by using the compound version when possible.
+
+
+**Recommended ✅**
+
+```swift
+if let username, let password, let passcode {
+    // ... do something with unwrapped values
+} else {
+    fatalError("Authentication Failed")
+}
+```
+
+**Not Recommended ❌**
+
+```swift
+if let username {
+    if let password {
+        if let passcode {
+            // ... do something with unwrapped values
+        } else {
+            fatalError("Authentication Failed")
+        }
+    } else {
+        fatalError("Authentication Failed")
+    }
+} else {
+    fatalError("Authentication Failed")
+}
+```
+
+
+In the compound version, which can't be fit on one line, place the `guard` / `if` on its own line, then indent each condition on a separate line.
+
+
+**Recommended ✅**
+
+```swift
+guard 
+  let username,
+  let email,
+  let password,
+  let passcode,
+  let securityAnswer
+else {
+  fatalError("Authentication Failed")
+}
+// ... do something with values
+```
+
+
 ### Providing Fallback Value
 
 Use the nil-coalescing operator as a shorthand method to provide a fallback value when unwrapping an optional, instead of using the ternary conditional operator and forced unwrapping.


### PR DESCRIPTION
By merging the `optionals` branch into `main`, the new 'Optionals' section is introduced in the Swift style guide. This section covers the following topics:

1. **Declaring Optionals**
2. **Unwrapping Optionals**
   - Force Unwrapping
   - Checking for nil
   - Optional Binding
3. **Providing Fallback Values**

Practical examples are included for both recommended and not recommended cases.
